### PR TITLE
Fix of PHPDoc

### DIFF
--- a/src/Classes/pData.php
+++ b/src/Classes/pData.php
@@ -48,8 +48,8 @@ class pData
 
     /**
      * Add a single point or an array to the given serie
-     * @param type $Values
-     * @param type $SerieName
+     * @param array $Values
+     * @param string $SerieName
      * @return int
      */
     public function addPoints($Values,$SerieName="Serie1")


### PR DESCRIPTION
The types should be stated IMO, or the word type should be removed from phpdocs, as it throws errors while in an IDE.
I'll try to fix this in a future pull request, just letting you know.