### PR TITLE
Raise the minimum PHP version to 5.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 sudo: false
 
 php:
-  - 5.5
+  - 5.6
 
 before_script:
   - composer self-update -n

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "files": ["src/Resources/data/constants.php"]
     },
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.6",
         "ext-gd": "*"
     },
     "require-dev" : {


### PR DESCRIPTION
A static analysis tool in Fedora has determined that
CpChart\Exception\ChartIsAMethodException requires a minimum of
PHP 5.6. This commit alters the composer.json file to require 5.6.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>