### PR TITLE
Ensure that $Alpha is an int

### DIFF
--- a/src/Chart/Draw.php
+++ b/src/Chart/Draw.php
@@ -5048,7 +5048,7 @@ abstract class Draw extends BaseDraw
                 $R = $Serie["Color"]["R"];
                 $G = $Serie["Color"]["G"];
                 $B = $Serie["Color"]["B"];
-                $Alpha = $Serie["Color"]["Alpha"];
+                $Alpha = (int) $Serie["Color"]["Alpha"];
                 $Ticks = $Serie["Ticks"];
                 if ($Surrounding != null) {
                     $BorderR = $R + $Surrounding;


### PR DESCRIPTION
If $Serie["Color"]["Alpha"] is an numeric string is breaks convertAlpha()