### PR TITLE
Calculate a more random $TemporaryFile name.

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -88,7 +88,7 @@ class Cache
     public function writeToCache($ID, Image $pChartObject)
     {
         /* Compute the paths */
-        $TemporaryFile = $this->CacheFolder . "/tmp_" . rand(0, 1000) . ".png";
+        $TemporaryFile = tempnam($this->CacheFolder, "tmp_");
         $Database = $this->CacheFolder . "/" . $this->CacheDB;
         $Index = $this->CacheFolder . "/" . $this->CacheIndex;
         /* Flush the picture to a temporary file */


### PR DESCRIPTION
Every now and then we see PHP Warnings: 
```
fopen(/tmp/pcache/tmp_729.png): failed to open stream
filesize(): stat failed for /tmp/pcache/tmp_729.png
```
This happens when there are multiple pCharts on a single page and two charts are given the same cache filenames. The current mechanism for calculating a random filename is a little rudimentary (basicall pick a number between 0 and 1000), which at times leads to two identical filenames. 
This PR proposes using PHP's tempnam() function which is a dedicated function for this very job.