### PR TITLE
feat: re-enable php 8.1 now that Travis supports it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
         - php: 7.3
         - php: 7.4
         - php: 8.0
-#        - php: 8.1
+        - php: 8.1.2
+          dist: focal
           env:
             - COVERAGE='--coverage --coverage-xml'
               XDEBUG_MODE=coverage

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr-4": { "CpChart\\Test\\": "tests/" }
     },
     "require": {
-        "php": "^5.4|^7.0|8.0.*",
+        "php": "^5.4|^7.0|^8.0",
         "ext-gd": "*"
     },
     "require-dev" : {


### PR DESCRIPTION
Tried updating my project to php 8.1 and this dependency was a blocker so I looked through the old commits and noticed the note about 8.1 in Travis not being supported at the time. 