### PR TITLE
Move casting values to integer to correct places

### DIFF
--- a/src/Draw.php
+++ b/src/Draw.php
@@ -1488,7 +1488,7 @@ abstract class Draw extends BaseDraw
             }
 
             $PlotColor = $this->allocateColor($this->Picture, $R, $G, $B, $Alpha);
-            imagesetpixel($this->Picture, $X, $Y, $PlotColor);
+            imagesetpixel($this->Picture, (int) $X, (int) $Y, $PlotColor);
 
             return 0;
         }

--- a/src/Draw.php
+++ b/src/Draw.php
@@ -857,10 +857,6 @@ abstract class Draw extends BaseDraw
      */
     public function drawLine($X1, $Y1, $X2, $Y2, array $Format = [])
     {
-        $X1 = (int) $X1;
-        $Y1 = (int) $Y1;
-        $X2 = (int) $X2;
-        $Y2 = (int) $Y2;
         $R = isset($Format["R"]) ? $Format["R"] : 0;
         $G = isset($Format["G"]) ? $Format["G"] : 0;
         $B = isset($Format["B"]) ? $Format["B"] : 0;
@@ -882,16 +878,16 @@ abstract class Draw extends BaseDraw
                 );
                 imageline(
                     $this->Picture,
-                    $X1 + $this->ShadowX,
-                    $Y1 + $this->ShadowY,
-                    $X2 + $this->ShadowX,
-                    $Y2 + $this->ShadowY,
+                    intval($X1 + $this->ShadowX),
+                    intval($Y1 + $this->ShadowY),
+                    intval($X2 + $this->ShadowX),
+                    intval($Y2 + $this->ShadowY),
                     $ShadowColor
                 );
             }
 
             $Color = $this->allocateColor($this->Picture, $R, $G, $B, $Alpha);
-            imageline($this->Picture, $X1, $Y1, $X2, $Y2, $Color);
+            imageline($this->Picture, (int) $X1, (int) $Y1, (int) $X2, (int) $Y2, $Color);
             return 0;
         }
 
@@ -1193,8 +1189,6 @@ abstract class Draw extends BaseDraw
      */
     public function drawText($X, $Y, $Text, array $Format = [])
     {
-        $X = (int) $X;
-        $Y = (int) $Y;
         $R = isset($Format["R"]) ? $Format["R"] : $this->FontColorR;
         $G = isset($Format["G"]) ? $Format["G"] : $this->FontColorG;
         $B = isset($Format["B"]) ? $Format["B"] : $this->FontColorB;
@@ -1453,8 +1447,6 @@ abstract class Draw extends BaseDraw
      */
     public function drawAntialiasPixel($X, $Y, array $Format = [])
     {
-        $X = (int) $X;
-        $Y = (int) $Y;
         $R = isset($Format["R"]) ? $Format["R"] : 0;
         $G = isset($Format["G"]) ? $Format["G"] : 0;
         $B = isset($Format["B"]) ? $Format["B"] : 0;
@@ -1492,7 +1484,7 @@ abstract class Draw extends BaseDraw
                     $this->ShadowB,
                     $this->Shadowa
                 );
-                imagesetpixel($this->Picture, $X + $this->ShadowX, $Y + $this->ShadowY, $ShadowColor);
+                imagesetpixel($this->Picture, intval($X + $this->ShadowX), intval($Y + $this->ShadowY), $ShadowColor);
             }
 
             $PlotColor = $this->allocateColor($this->Picture, $R, $G, $B, $Alpha);
@@ -1545,9 +1537,6 @@ abstract class Draw extends BaseDraw
      */
     public function drawAlphaPixel($X, $Y, $Alpha, $R, $G, $B)
     {
-        $X = (int) $X;
-        $Y = (int) $Y;
-
         if (isset($this->Mask[$X]) && isset($this->Mask[$X][$Y])) {
             return 0;
         }
@@ -1589,7 +1578,7 @@ abstract class Draw extends BaseDraw
         }
 
         $C_Aliased = $this->allocateColor($this->Picture, $R, $G, $B, $Alpha);
-        imagesetpixel($this->Picture, $X, $Y, $C_Aliased);
+        imagesetpixel($this->Picture, (int) $X, (int) $Y, $C_Aliased);
     }
 
     /**


### PR DESCRIPTION
We tried updating this lib to the latest version in Matomo. But it seems the latest fixes for PHP 8.1 are causing a slightly change in the resulting images. 

We have a couple of tests that check if code changes have an effect on our generated graphs and updating the lib did so. You can see the changes e.g. here: https://builds-artifacts.matomo.org/matomo-org/matomo/composer-update/57946/ImageGraph_evolution_graph.png

I was able to narrow down, that those changes are caused by the early int casting in the drawing methods. Casting the values in the beginning causes the calculations that follow in some of that methods to have different results. 

I've changed those methods to do the casting only when passing values to image* methods. This helped to have the same image results as before.