### PR TITLE
Update Pie.php

### DIFF
--- a/src/Chart/Pie.php
+++ b/src/Chart/Pie.php
@@ -1156,7 +1156,7 @@ class Pie
             }
         }
 
-        $this->Shadow = $RestoreShadow;
+        $this->pChartObject->Shadow = $RestoreShadow;
     }
 
     /**

--- a/src/Chart/Scatter.php
+++ b/src/Chart/Scatter.php
@@ -1416,7 +1416,7 @@ class Scatter
             );
         }
         $RestoreShadow = $this->pChartObject->Shadow;
-        $this->Shadow = false;
+        $this->pChartObject->Shadow = false;
         foreach ($Data["ScatterSeries"] as $Key => $Series) {
             if ($Series["isDrawable"] == true) {
                 $R = $Series["Color"]["R"];
@@ -1535,7 +1535,7 @@ class Scatter
             }
         }
 
-        $this->Shadow = $RestoreShadow;
+        $this->pChartObject->Shadow = $RestoreShadow;
     }
 
     /**
@@ -2244,7 +2244,7 @@ class Scatter
                     ]
                 );
                 if ($DisableShadowOnArea) {
-                    $this->Shadow = false;
+                    $$this->pChartObject->Shadow = false;
                 }
             }
 

--- a/src/Chart/Spring.php
+++ b/src/Chart/Spring.php
@@ -74,6 +74,21 @@ class Spring
      */
     public $AutoComputeFreeZone = false;
 
+    /**
+     * @var int|float
+     */
+    private $MagneticForceA;
+
+    /**
+     * @var int|float
+     */
+    private $MagneticForceR;
+
+    /**
+     * @var int|float
+     */
+    private $RingSize;
+
     public function __construct()
     {
         /* Set nodes defaults */


### PR DESCRIPTION
Fix PHP 8.2 deprecation: Creation of dynamic property `CpChart\\Chart\\Pie::$Shadow` is deprecated. This happens because the property Shadow belongs to `$this->pChartObject` and not to `$this`.